### PR TITLE
Necessário informar um PUBLIC_KEY

### DIFF
--- a/lib/src/card/card_repository.dart
+++ b/lib/src/card/card_repository.dart
@@ -53,7 +53,7 @@ class CardRepository {
       };
 
       final result = await request.post(
-          path: 'v1/card_tokens', acessToken: acessToken, data: card);
+          path: 'v1/card_tokens?public_key=PUBLIC_KEY', acessToken: acessToken, data: card);
       final id = result['id'];
 
       print(id);


### PR DESCRIPTION
Para que retorne o token há a necessidade de informar um public_key junto a URL