### PR TITLE
Métodos: 'getInstallments' e 'getIssuerId'

### DIFF
--- a/lib/src/card/card_repository.dart
+++ b/lib/src/card/card_repository.dart
@@ -97,4 +97,19 @@ class CardRepository {
     }
     return result;
   }
+
+  /// Retorna o nome do emissor do cartao atraves do número informado: 'master', 'visa' etc...
+  Future<String?> getIssuerId({required String cardNumber}) async {
+    String? result;
+    try {
+      final params = Uri(queryParameters: {'bins': cardNumber.replaceAll(' ', '').substring(0, 8)}).query;
+
+      final resp = await request.get(path: 'v1/payment_methods/search?$params', acessToken: acessToken);
+
+      result = resp['results'][0]['id'];
+    } catch (e) {
+      return throw e;
+    }
+    return result;
+  }
 }

--- a/lib/src/card/installment_model.dart
+++ b/lib/src/card/installment_model.dart
@@ -1,0 +1,66 @@
+class InstallmentModel {
+  int? installments;
+  int? installmentRate;
+  int? discountRate;
+  List<String?>? installmentRateCollector;
+  double? minAllowedAmount;
+  double? maxAllowedAmount;
+  String? recommendedMessage;
+  double? installmentAmount;
+  double? totalAmount;
+  String? paymentMethodOptionId;
+
+  InstallmentModel({
+    this.installments,
+    this.installmentRate,
+    this.discountRate,
+    this.installmentRateCollector = const [],
+    this.minAllowedAmount,
+    this.maxAllowedAmount,
+    this.recommendedMessage,
+    this.installmentAmount,
+    this.totalAmount,
+    this.paymentMethodOptionId,
+  });
+
+  InstallmentModel.fromJson(Map<String, dynamic> json) {
+    installments = json['installments']?.toInt();
+    installmentRate = json['installment_rate']?.toInt();
+    discountRate = json['discount_rate']?.toInt();
+    if (json['installment_rate_collector'] != null) {
+      installmentRateCollector = <String>[];
+      for (var item in json['installment_rate_collector']) {
+        installmentRateCollector!.add(item.toString());
+      }
+    }
+    minAllowedAmount = json['min_allowed_amount']?.toDouble();
+    maxAllowedAmount = json['max_allowed_amount']?.toDouble();
+    recommendedMessage = json['recommended_message']?.toString();
+    installmentAmount = json['installment_amount']?.toDouble();
+    totalAmount = json['total_amount']?.toDouble();
+    paymentMethodOptionId = json['payment_method_option_id']?.toString();
+  }
+
+  static List<InstallmentModel> listFromJson(List jsonList) {
+    final result = <InstallmentModel>[];
+    for (var item in jsonList) {
+      result.add(InstallmentModel.fromJson(item));
+    }
+    return result;
+  }
+
+  Map<String, dynamic> toJson() {
+    final data = <String, dynamic>{};
+    data['installments'] = installments;
+    data['installment_rate'] = installmentRate;
+    data['discount_rate'] = discountRate;
+    data['installment_rate_collector'] = installmentRateCollector.toString();
+    data['min_allowed_amount'] = minAllowedAmount;
+    data['max_allowed_amount'] = maxAllowedAmount;
+    data['recommended_message'] = recommendedMessage;
+    data['installment_amount'] = installmentAmount;
+    data['total_amount'] = totalAmount;
+    data['payment_method_option_id'] = paymentMethodOptionId;
+    return data;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   charcode:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,28 +80,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -113,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -134,21 +134,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
São os dois novos métodos do arquivo `lib/src/card/card_repository.dart`. 

Ainda assim o ideal seria que este package não solicitasse o acessToken que deveria ser uma chave completamente oculta, ou seja, para ser usada apenas por um backend. Os dois métodos que estão subindo neste PR usam o accessToken, mas poderia tranquilamente ser substituídos pelo publicKey, porém isso não foi feito aqui porque a estrutura do package não foi feita pra isso.